### PR TITLE
Add related article suggestions

### DIFF
--- a/live-chat.php
+++ b/live-chat.php
@@ -1392,6 +1392,13 @@ class MorwebSupportChat {
         
         return results;
     }
+
+    getRelatedArticles(query, currentResults, limit = 3) {
+        const additional = this.searchArticles(query, currentResults.length + limit)
+            .filter(r => !currentResults.some(cr => cr.url === r.url))
+            .slice(0, limit);
+        return additional;
+    }
     
     preprocessQuery(query) {
         return query.toLowerCase()
@@ -1602,6 +1609,15 @@ class MorwebSupportChat {
         
         setTimeout(() => {
             this.displayArticleResults(results);
+
+            const related = this.getRelatedArticles(query, results);
+            if (related.length > 0) {
+                this.addMessage('You might also like:', 'bot');
+                this.displayArticleResults(related);
+                this.lastSearchResults = [...results, ...related];
+            } else {
+                this.lastSearchResults = results;
+            }
         }, 500);
     }
     


### PR DESCRIPTION
## Summary
- add `getRelatedArticles` helper to compute suggestions
- show "You might also like" section after displaying search results

## Testing
- `php -l live-chat.php`

------
https://chatgpt.com/codex/tasks/task_b_6878604245808333a2c06a9a1bcc0bba